### PR TITLE
fix event binding for block

### DIFF
--- a/clientApp.js
+++ b/clientApp.js
@@ -269,8 +269,8 @@ module.exports = function() {
 
             // Пробегаемся по ассоциативному массиву элементов, заданном в модуле
             _.each(elements, function(eventsConfig, elementName) {
-                var selector = eventsConfig.selector || '.' + namer.elementClass(module.block || module.type, elementName),
-                    selectorDashed = eventsConfig.selector || '.' + namer.elementClass(module.type, elementName, true),
+                var selector = eventsConfig.selector || '.' + namer.elementClass(module.instance.block || module.type, elementName),
+                    selectorDashed = eventsConfig.selector || '.' + namer.elementClass(module.instance.block || module.type, elementName, true),
                     containerId = moduleBlockId(moduleId);
 
                 // Выбираем все значения из объекта, за исключением селектора


### PR DESCRIPTION
при переиспользовании стилей используется имя не модуля, а имя прототипа 

а package.json версию не надо самому менять?

https://jira.2gis.ru/browse/ONLINE-2528
