### PR TITLE
add extendTmplHelpers fn

### DIFF
--- a/app.js
+++ b/app.js
@@ -464,6 +464,8 @@ module.exports = function() {
             var moduleWrapperConstructor = require('./moduleWrapper'),
                 moduleWrapper = moduleWrapperConstructor(app, module, slot);
 
+            app.fetchTmplHelpers(slot);
+
             // Модуль убивается (анбиндинг, удаление асинхронных функций), но сохраняется в дом-дереве
             var kill = function() {
                 if (!moduleWrapper || slot.stage == slot.STAGE_KILLED) return;
@@ -575,11 +577,25 @@ module.exports = function() {
         registry: registry,
 
         /**
-         * Для переопределения в конечных продуктах
-         * вызывается на каждом новом слоте
-         * @param slot
+         * Вызывается на каждом новом слоте
+         *
+         * @param {Object} slot
+         *
+         * # Для переопределения в конечных продуктах
          */
         setupSlot: function(slot) {
+
+        },
+
+        /**
+         * Собирает кастомные template helpers
+         * Вызывается после создания каждого нового moduleWrapper
+         *
+         * @param {Object} slot
+         *
+         * # Для переопределения в конечных продуктах
+         */
+        fetchTmplHelpers: function(slot) {
 
         },
 

--- a/moduleWrapper.js
+++ b/moduleWrapper.js
@@ -62,8 +62,11 @@ module.exports = function(app, moduleConf, slot) {
         }
     };
 
-    slot.extendHelpers(templateHelpers); // для расширения в конечных приложениях
-    slot.extendPartials(templatePartials); // для расширения в конечных приложениях
+    slot.templateHelpers = templateHelpers;
+
+    slot.extendTmplHelpers = function(helpersToAdd) {
+        _.extend(templateHelpers, helpersToAdd);
+    };
 
     function getTmplOptions() {
         var options = {},

--- a/slot.js
+++ b/slot.js
@@ -229,16 +229,6 @@ module.exports = function(app, params) {
             }
         },
 
-        /**
-         * Заглушка для расширения хелперов в moduleWrapper
-         */
-        extendHelpers: function() {},
-
-        /**
-         * Заглушка для расширения партиалов в moduleWrapper
-         */
-        extendPartials: function() {},
-
         cookie: app.cookie
     };
 


### PR DESCRIPTION
1. Теперь templateHelpers доступны в slot.templateHelpers и можно создавать, например, прелюдии для partial, которые из-за своей кастомности не надо держать в общих хелперах
2. Расширять templateHelpers следует через функцию slot.extendTmplHelpers, чтобы если мы захотим изменить место хранения кастомных хелперов, мы сделали это в одном месте
3. Называть кастомные хелперы стоит с подчеркивания ("_regionByNamePartial"), чтобы при просмотре шаблона было понятно, что хелпер кастомный
