### PR TITLE
Обращается к несуществующему объекту app.config.devPages

### DIFF
--- a/app.js
+++ b/app.js
@@ -148,18 +148,20 @@ module.exports = function() {
         },
 
         resolveEntryPoint: function(req, appState) {
-            var url = req.url,
+            req = req || {};
+
+            var url = req.url || '',
                 name = app.config.mainModule,
                 slug = url.split('/')[0];
 
             // То самое место, где вместо online подставляется makeup
-            var devPageConfig = app.config.devPages[slug];
+            var devPageConfig = app.config.devPages && app.config.devPages[slug];
             if (DEBUG && devPageConfig) {
                 name = devPageConfig.module;
                 historyDisabled = !devPageConfig.history; // Чтоб запретить модификацию урла в мейкапе
             }
 
-            if (app.config.isLandingPage(req)) {
+            if (app.config.isLandingPage && app.config.isLandingPage(req)) { // @TODO выпилить зависимость четвёрки
                 name = 'landingPage';
             }
 
@@ -683,6 +685,11 @@ module.exports = function() {
         getModificators: getModificators
     };
 
+    var out = {
+        instance: smokesignals.convert(app),
+        internals: internals
+    };
+
     if (DEBUG) {
         env.global.app = app;
 
@@ -695,10 +702,9 @@ module.exports = function() {
         app.findModule = function(type) {
             return app.modulesByType(type)[0];
         };
+
+        out.appConfig = app;
     }
 
-    return {
-        instance: smokesignals.convert(app),
-        internals: internals
-    };
+    return out;
 };

--- a/tests/app.spec.js
+++ b/tests/app.spec.js
@@ -1,19 +1,41 @@
 var assert = require('assert');
 
-describe.skip('Core -> app', function() {
-    var app = require('../app.js');
+DEBUG = true;
+
+describe('Core -> app', function() {
+    var app;
+
+    beforeEach(function() {
+        app = require('../app.js');
+    });
 
     it('blank', function() {
-
         assert(app);
     });
 
-    describe('-> getModificators', function() {
+    describe('-> resolveEntryPoint', function() {
+        it('Не падает когда devPages нет в конфиге', function(done) {
+            var cfg = app().appConfig;
+
+            cfg.config = {};
+            cfg.loadModule = function() {};
+
+            cfg.resolveEntryPoint();
+            done();
+        });
+    });
+
+    describe.skip('-> getModificators', function() {
         var mods;
-        var appInstance = app().instance;
-        var moduleWrapper = {
-            type: 'online'
-        };
+        var appInstance;
+        var moduleWrapper;
+
+        before(function() {
+            appInstance = app().instance;
+            moduleWrapper = {
+                type: 'online'
+            };
+        });
 
         it('Элемент moduleWrapper.block()[0] есть объект', function() {
             moduleWrapper.block = function() {
@@ -34,7 +56,7 @@ describe.skip('Core -> app', function() {
         });
     });
 
-    describe('-> cookie', function() {
+    describe.skip('-> cookie', function() {
         it('Выставление значения на сервере', function() {
             var callback = sinon.spy();
             app.on('cookie', callback);


### PR DESCRIPTION
После обновления слота в виджетах, слот стал запрашивать несуществующий объект `devPages` в строчке https://github.com/2gis/slot/blob/master/app.js#L156
