### PR TITLE
Удалить лишние require('smokesignals')

### DIFF
--- a/modulesQuering.js
+++ b/modulesQuering.js
@@ -1,6 +1,4 @@
-
-var _ = require('lodash'),
-    smokesignals = envRequire('smokesignals');
+var _ = require('lodash');
 
 module.exports = function(internals) {
 

--- a/slot.js
+++ b/slot.js
@@ -1,6 +1,5 @@
 var async = require('async'),
-    _ = require('lodash'),
-    smokesignals = envRequire('smokesignals');
+    _ = require('lodash');
 
 module.exports = function(app, params) {
     var moduleId = params.moduleId,


### PR DESCRIPTION
В файлах `modulesQuering.js` и `slot.js` происходит подключение либы smokesignals, но она нигде там не используется. Почистить.
