### PR TITLE
Прикрутить code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ node_modules
 /.idea/*
 /nbproject/*
 /nbproject/private/
+/coverage/*
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "colors": "~1.0.3",
     "gulp": "~3.8.6",
+    "gulp-istanbul": "^0.3.1",
     "gulp-jscs": "git://github.com/anru/gulp-jscs.git",
     "gulp-jshint": "~1.6.3",
     "gulp-mocha": "~0.5.1",

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -1,14 +1,27 @@
 var gulp = require('gulp');
 var mocha = require('gulp-mocha');
+var istanbul = require('gulp-istanbul');
 
-gulp.task('test', function() {
+gulp.task('test', ['cover'], function() {
     return gulp.src([
         'tests/unitTestConfig.js',
         '**/*.spec.js'
     ], {read: false})
         .pipe(mocha({
             globals: ['DEBUG']
+        }))
+        .pipe(istanbul.writeReports({
+            dir: './coverage',
+            reporters: [ 'lcov', 'text']
         }));
+});
+
+gulp.task('cover', function(){
+    return gulp.src([
+        '*.js',
+        'clientApp/*.js',
+        '!clientApp/*.spec.js'
+    ]).pipe(istanbul());
 });
 
 gulp.task('default', ['test']);


### PR DESCRIPTION
При запуске тестов делать отчет по code coverage.
Использовать istanbul. Генерировать отчет в консоли и создавать html документ.
