### PR TITLE
Избавиться от старого метода stuff.deepClone

### DIFF
--- a/lib/stuff.js
+++ b/lib/stuff.js
@@ -127,23 +127,6 @@ var stuff = module.exports = {
         return obj;
     },
 
-    deepClone: function(obj) {
-        if (!_.isObject(obj)) return obj;
-        if (_.isArray(obj)) {
-            return _.map(obj, function(elem) {
-                return stuff.deepClone(elem);
-            });
-        }
-        var x = {};
-        for (var name in obj) {
-            if (obj.hasOwnProperty(name)) {
-                x[name] = stuff.deepClone(obj[name]);
-            }
-        }
-
-        return x;
-    },
-
     state2uri: function(state, encode) {
         var parts = [];
         for (var key in state) {


### PR DESCRIPTION
В файле `stuff.js` есть метод `deepClone`, который полностью повторяет поведение `_.cloneDeep`.  Удалить метод. Во всех проектах завязанных на этот метод заменить на метод из `lodash`

СЛИВАТЬ ТОЛЬКО ПОСЛЕ https://github.com/2gis/online4/pull/1822
