### PR TITLE
jsdoc-add-readme-md-and-fix-lib-removing

### DIFF
--- a/tasks/docs.js
+++ b/tasks/docs.js
@@ -7,7 +7,20 @@ var jsdoc = require('gulp-jsdoc');
 gulp.task('docs', function() {
     del.sync('docs/api');
 
-    return gulp.src(['*.js', '!gulpfile.js', 'clientApp/index.js', 'clientApp/transitions.js'])
+    return gulp.src([
+        'config.js',
+        'env.js',
+        'slot.js',
+        'moduleConstructor.js',
+        'app.js',
+        'serverApp.js',
+        'clientApp/index.js',
+        'clientApp/transitions.js',
+
+        'lib/*.js',
+
+        'README.md'
+    ])
         .pipe(jsdoc.parser({
             plugins: ['plugins/markdown']
         }))


### PR DESCRIPTION
На начальной странице апи-документации теперь выводиться README.md
