### PR TITLE
Добавить в slot функцию invoke из app

### DIFF
--- a/slot.js
+++ b/slot.js
@@ -45,6 +45,7 @@ module.exports = function(app, params) {
 
         addTransition: app.addTransition,
         runInQueue: app.runInQueue,
+        invoke: app.invoke,
 
         /**
          * Инициализирует модуль.


### PR DESCRIPTION
Чтобы не приходилось при надобности в конечном продукте делать так:
`slot.invoke = app.invoke;`
и выкосить из онлайна это.
