### PR TITLE
Конфиг должен передаваться от приложения, а не подключаться в слоте

### DIFF
--- a/config.js
+++ b/config.js
@@ -5,11 +5,9 @@
 var env = require('./env'),
     _ = require('lodash');
 
-var cfg = typeof window == 'undefined' ? env.requirePrivate('config') : dg.config;
+var cfg = env.getConfig();
 
 module.exports = cfg;
-
-env.global.DEBUG = cfg.debug;
 
 module.exports.group = function(name) {
     var ret = {};
@@ -20,24 +18,4 @@ module.exports.group = function(name) {
         }
     }
     return ret;
-};
-
-module.exports.merge = function(upstream) {
-    for (var key in upstream) {
-        if (upstream.hasOwnProperty(key)) {
-            var value = upstream[key];
-            var doPush = false;
-            if (key.charAt(0) == '+') {
-                doPush = true;
-                key = key.substr(1);
-            }
-
-            var origin = cfg[key];
-            if (doPush && key in cfg && _.isArray(origin)) {
-                origin.push.apply(origin, value);
-            } else {
-                cfg[key] = value;
-            }
-        }
-    }
 };

--- a/tests/app.spec.js
+++ b/tests/app.spec.js
@@ -155,16 +155,6 @@ describe('app', function() {
         });
     });
 
-    describe('-> resolveEntryPoint', function() {
-        it('Не падает когда devPages нет в конфиге', function(done) {
-            appConfig.config = {};
-            appConfig.loadModule = function() {};
-
-            appConfig.resolveEntryPoint();
-            done();
-        });
-    });
-
     describe.skip('-> getModificators', function() {
         var mods;
         var appInstance;


### PR DESCRIPTION
Проблема:
Проект имеет несколько точек входа, каждая из которых использует конфиг.
Например:
- клиент
- сервер
- консольные скрипты
- такс-менеджер

Каждая точка входа сейчас должна задавать корневой путь. 
Следует сделать, чтобы и конфиг задавался в зависимости от точки входа, потому что для последних двух приложение не обязательно должно быть собранным (иметь `env.requirePrivate('config')`). Также это избавляет slot от привязки к глобальной `dg.config`.

По дороге убрала неиспользуемый параметр из `serverApp.js`
