### PR TITLE
Развязать request-logger

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -27,8 +27,7 @@ module.exports = typeof window == 'undefined' ? serverRequest : clientRequest;
  * @returns {*}
  */
 function serverRequest(conf) {
-    var request = require('request'),
-        winston = require('./logger');
+    var request = require('request');
 
     if (conf.method && conf.method.toLowerCase() == 'post') {
         conf.form = conf.data;
@@ -47,13 +46,6 @@ function serverRequest(conf) {
     return request(conf, function(error, xhr, body) {
         if (error) {
             conf.error.call(conf.context, xhr, error);
-
-            winston.error("Couldn't do request", {
-                url: conf.url,
-                params: conf,
-                statusCode: xhr && xhr.statusCode,
-                error: error + ''
-            });
         } else {
             try {
                 body = conf.type.match(/^json/) ? JSON.parse(body) : body;


### PR DESCRIPTION
Сейчас lib/request зависит от lib/logger.
Это можно и нужно делать на стороне приложения и только при надобности.
