### PR TITLE
Поддержка множественных предикатов в app.queryModules

### DIFF
--- a/lib/modulesQuering.js
+++ b/lib/modulesQuering.js
@@ -32,12 +32,12 @@ module.exports = function(moduleDescriptors) {
      *
      * @param {string} fromId - С какого модуля фильтруем.
      * @param {string} name - Тип модулей который нужен, если равен * то любой тип подходит.
-     * @param {Object} predicate - Распарсенный объект предиката, см. метод parsePredicate.
+     * @param {Object[]} predicates - Массив распарсенных объектов предикатов, см. метод parsePredicate.
      * @param {boolean} [inclusive=false] - Включать ли начальный модуль в выборку.
      *
      * @returns {Array<string>} Список отфильтрованных айдишников.
      */
-    function filterModules(fromId, name, predicate, inclusive) {
+    function filterModules(fromId, name, predicates, inclusive) {
         var currModuleDesc = moduleDescriptors[fromId],
             result = [];
 
@@ -56,36 +56,39 @@ module.exports = function(moduleDescriptors) {
          * @param {Array} all - Все родительские модули.
          * @returns {boolean}
          */
-        function matchPredicate(moduleConf, moduleDesc, index, all) {
-            if (!predicate) return true;
+        function matchPredicates(moduleConf, moduleDesc, index, all) {
+            return _.every(predicates, function(predicate) {
+                if (predicate.type & predicateTypes.METHOD) {
+                    if (!moduleConf.interface || !_.isFunction(moduleConf.interface[predicate.name])) {
+                        return false;
+                    }
+                    var ref = predicate.ref == null ? true : predicate.ref;
 
-            if (predicate.type & predicateTypes.METHOD) {
-                if (!moduleConf.interface || !_.isFunction(moduleConf.interface[predicate.name])) {
-                    return false;
+
+                    return moduleConf.interface[predicate.name].apply(moduleConf, predicate.args) == ref;
+                } else if (predicate.type & predicateTypes.MOD) {
+                    var mods = moduleDesc.slot.mod();
+                    var value = mods[predicate.name];
+
+                    if (!predicate.ref) {
+                        return value === true;
+                    } else if (predicate.ref == '*') {
+                        return value != null && value != false;
+                    } else {
+                        return value == predicate.ref;
+                    }
+                } else if (predicate.type & predicateTypes.ATOM) {
+                    switch (predicate.name) {
+                        case 'first-child':
+                            return index == 0;
+                        case 'last-child':
+                            return index == all.length - 1;
+                        case 'first':
+                        case 'last':
+                            return true;
+                    }
                 }
-                var ref = predicate.ref == null ? true : predicate.ref;
-
-
-                return moduleConf.interface[predicate.name].apply(moduleConf, predicate.args) == ref;
-            } else if (predicate.type & predicateTypes.MOD) {
-                var mods = moduleDesc.slot.mod();
-                var value = mods[predicate.name];
-
-                if (!predicate.ref) {
-                    return value === true;
-                } else if (predicate.ref == '*') {
-                    return value != null && value != false;
-                } else {
-                    return value == predicate.ref;
-                }
-            } else if (predicate.type & predicateTypes.ATOM) {
-                switch (predicate.name) {
-                    case 'first':
-                        return index == 0;
-                    case 'last':
-                        return index == all.length - 1;
-                }
-            }
+            });
         }
 
         /**
@@ -100,7 +103,7 @@ module.exports = function(moduleDescriptors) {
         function accumulate(id, index, all) {
             var moduleDesc = moduleDescriptors[id];
 
-            if (matchType(moduleDesc.type) && matchPredicate(moduleDesc.moduleConf, moduleDesc, index, all)) {
+            if (matchType(moduleDesc.type) && matchPredicates(moduleDesc.moduleConf, moduleDesc, index, all)) {
                 result.push(id);
             }
 
@@ -113,6 +116,16 @@ module.exports = function(moduleDescriptors) {
             _.each(currModuleDesc.children, accumulate);
         }
 
+        // если последний предикат — :first или :last, возвращаем первый или последний модуль из выборки
+        var lastPredicate = _.last(predicates);
+        if (result.length && lastPredicate && lastPredicate.type & predicateTypes.ATOM) {
+            switch (lastPredicate.name) {
+                case 'first':
+                    return result.slice(0, 1);
+                case 'last':
+                    return result.slice(-1);
+            }
+        }
         return result;
     }
 
@@ -130,7 +143,7 @@ module.exports = function(moduleDescriptors) {
         var sel = selector.split(/\s+/);
 
         // элемент каскада
-        var ruleRe = /([\w\*]+)(\[([^\]]+)\])?/;
+        var ruleRe = /([\w\*]+)((?:\[[^\]]+\])*)/;
         // один аргумент в конструкции [::foo(1, 'arg2', "arg3')]
         var argsRe = /(?:"(?:\\.|[^"])*"|'(?:\\.|[^'])*'|[^"'\s\,]+)+/g;
         // регулярка на все аргументы вместе со скобками, сами аргументы могут отсутствовать
@@ -195,6 +208,8 @@ module.exports = function(moduleDescriptors) {
 
         // итерация по элементам каскада, каждый раз выборка уточняется
         for (var i = 0, len = sel.length; i < len; i++) {
+            // предикат
+            var predRe = /\[([^\]]+?)\]/g;
             var rule = ruleRe.exec(sel[i]);
 
             if (!rule) {
@@ -202,13 +217,20 @@ module.exports = function(moduleDescriptors) {
             }
 
             var name = rule[1];
-            var predicate = rule[3] && parsePredicate(rule[3]);
+            var predicatesString = rule[2];
+
+            var predicates = [],
+                predicateMatch;
+
+            while (predicateMatch = predRe.exec(predicatesString)) {
+                predicates.push(parsePredicate(predicateMatch[1]));
+            }
 
             var newIds = [];
 
             for (var k = 0, kLen = ids.length; k < kLen; k++) {
                 var id = ids[k];
-                newIds = newIds.concat(filterModules(id, name, predicate, inclusive));
+                newIds = newIds.concat(filterModules(id, name, predicates, inclusive));
             }
 
             inclusive = false; // далее inclusive должен быть равен false для корректной выборки в каскаде

--- a/tests/modulesQuering.spec.js
+++ b/tests/modulesQuering.spec.js
@@ -3,7 +3,7 @@ var Quering = require('../lib/modulesQuering'),
     _ = require('lodash'),
     assert = require('assert');
 
-describe("ModulesQuering", function() {
+describe('ModulesQuering', function() {
 
     var m = function(cfg) {
         return _.defaults(cfg, {
@@ -17,12 +17,12 @@ describe("ModulesQuering", function() {
     };
 
     var moduleDescriptors = {
-        "1": m({
-            type: "root",
-            children: ["1-1", "1-2"]
+        '1': m({
+            type: 'root',
+            children: ['1-1', '1-2']
         }),
-        "1-1": m({
-            type: "moscow",
+        '1-1': m({
+            type: 'moscow',
             moduleConf: {
                 interface: {
                     now: function(id) {
@@ -35,10 +35,10 @@ describe("ModulesQuering", function() {
                     return {'active': true};
                 }
             },
-            children: ["1-1-1", "1-1-2"]
+            children: ['1-1-1', '1-1-2']
         }),
-        "1-2": m({
-            type: "moscow",
+        '1-2': m({
+            type: 'moscow',
             moduleConf: {
                 interface: {
                     now: function(id) {
@@ -46,10 +46,10 @@ describe("ModulesQuering", function() {
                     }
                 }
             },
-            children: ["1-2-1"]
+            children: ['1-2-1']
         }),
-        "1-1-1": m({
-            type: "himki",
+        '1-1-1': m({
+            type: 'himki',
             slot: {
                 mod: function() {
                     return {'active': 1};
@@ -63,12 +63,12 @@ describe("ModulesQuering", function() {
                 }
             }
         }),
-        "1-1-2": m({
-            type: "birulevo"
+        '1-1-2': m({
+            type: 'birulevo'
 
         }),
-        "1-2-1": m({
-            type: "himki"
+        '1-2-1': m({
+            type: 'himki'
         })
     };
 
@@ -78,63 +78,63 @@ describe("ModulesQuering", function() {
         return moduleDescriptors[id];
     }
 
-    it("Простой селектор", function() {
-        assert.deepEqual(query('1', 'moscow')[0], byId("1-1"));
+    it('Простой селектор', function() {
+        assert.deepEqual(query('1', 'moscow')[0], byId('1-1'));
     });
 
-    it("Составной с предикатам по модификатору", function() {
+    it('Составной с предикатам по модификатору', function() {
         var r = query('1', 'moscow[active] himki');
-        assert.equal(r.length, 1, "himki=1, actual:" + r.length);
+        assert.equal(r.length, 1, 'himki=1, actual:' + r.length);
 
-        assert.deepEqual(r[0], byId("1-1-1"));
+        assert.deepEqual(r[0], byId('1-1-1'));
     });
 
-    it("Составной с предикатам по методу", function() {
+    it('Составной с предикатам по методу', function() {
         var r = query('1', 'moscow[::now(1)] himki');
-        assert.equal(r.length, 1, "himki=1, actual:" + r.length);
+        assert.equal(r.length, 1, 'himki=1, actual:' + r.length);
 
-        assert.deepEqual(r[0], byId("1-1-1"));
+        assert.deepEqual(r[0], byId('1-1-1'));
     });
 
-    it("Составной с предикатам по методу которого нет", function() {
+    it('Составной с предикатам по методу которого нет', function() {
         var r = query('1', 'moscow[::sg(1)]');
-        assert.equal(r.length, 0, "himki=0, actual:" + r.length);
+        assert.equal(r.length, 0, 'himki=0, actual:' + r.length);
     });
 
     it('Простой с предикатом на вложенный элемент', function() {
         var r = query('1', 'himki[::xx(6)]');
-        assert.equal(r.length, 1, "himki=1, actual:" + r.length);
+        assert.equal(r.length, 1, 'himki=1, actual:' + r.length);
 
-        assert.deepEqual(r[0], byId("1-1-1"));
+        assert.deepEqual(r[0], byId('1-1-1'));
     });
 
     it('Простой на вложенный элемент', function() {
         var r = query('1', 'himki');
-        assert.equal(r.length, 2, "himki=2, actual:" + r.length);
+        assert.equal(r.length, 2, 'himki=2, actual:' + r.length);
 
-        assert.deepEqual(r[0], byId("1-1-1"));
+        assert.deepEqual(r[0], byId('1-1-1'));
     });
 
-    it("wildcard с предикатами", function() {
+    it('wildcard с предикатами', function() {
         var r = query('1', '*[::now(2)]');
         assert.equal(r.length, 1);
 
-        assert.deepEqual(r[0], byId("1-2"));
+        assert.deepEqual(r[0], byId('1-2'));
     });
 
-    it('предикат :first', function() {
-        var r = query('1', 'moscow[:first]');
+    it('предикат :first-child', function() {
+        var r = query('1', 'moscow[:first-child]');
         assert.equal(r.length, 1);
         assert.deepEqual(r[0], byId('1-1'));
     });
 
-    it('предикат :last', function() {
-        var r = query('1', 'moscow[:last]');
+    it('предикат :last-child', function() {
+        var r = query('1', 'moscow[:last-child]');
         assert.equal(r.length, 1);
         assert.deepEqual(r[0], byId('1-2'));
     });
 
-    it("предикат с модификатором", function() {
+    it('предикат с модификатором', function() {
         var r = query('1', '*[active]');
         assert.equal(r.length, 1);
 
@@ -157,8 +157,30 @@ describe("ModulesQuering", function() {
         assert.deepEqual(r[0], byId('1'));
     });
 
-    it("все модули", function() {
+    it('все модули', function() {
         assert.equal(query('1', '*').length, 5);
     });
 
+    it('несколько предикатов', function() {
+        r = query('1', '*[active=*][::xx(6)]');
+        assert.equal(r.length, 1);
+        assert.deepEqual(r[0], byId('1-1-1'));
+
+        r = query('1', 'moscow[::now(1)][qwe]');
+        assert.equal(r.length, 0);
+    });
+
+    it('предикаты :last и :first', function() {
+        r = query('1', 'moscow[:first]');
+        assert.equal(r.length, 1);
+        assert.deepEqual(r[0], byId('1-1'));
+
+        r = query('1', 'moscow[:last]');
+        assert.equal(r.length, 1);
+        assert.deepEqual(r[0], byId('1-2'));
+
+        r = query('1', '*[active=*][:last]');
+        assert.equal(r.length, 1);
+        assert.deepEqual(r[0], byId('1-1-1'));
+    });
 });


### PR DESCRIPTION
Сейчас модули можно запрашивать по таким селекторам:

`moduleName[::methodName(1)]`
`moduleName[:last]`

Необходима возможность использовать несколько предикатов в одном элементе каскада:

`moduleName[::methodName(1)][:last]`

_Решение:_

Теперь корректно работают комбинации предикатов вроде `[modifier1][modifier2][modifier3]`.

`[:first]` переименован в `[:first-child]`
`[:last]` переименован в `[:last-child]`
но в конечных приложениях в большинстве кейсов можно пользоваться и `first` и `first-child`, они в почти равнозначны:

:first/:last теперь выполняют функцию "первый/последний модуль из текущей выборки", их можно добавлять только в конце элемента каскада:
- `moduleName[:first]` - первый модуль типа `moduleName`
- `moduleName[isActive][:last]` берет последний активный модуль типа `moduleName`
