### PR TITLE
2 часа моей жизни. накой это перезаписывается?

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -38,7 +38,7 @@ function serverRequest(conf) {
     _.defaults(conf, {
         success: _.noop,
         error: _.noop,
-        complete: _.noop,
+        complete: _.noop
     });
 
     // @doclink: https://github.com/mikeal/request#requestoptions-callback


### PR DESCRIPTION
Долго не мог понять, почему библиотека request в проекте при работает с сертификатами так криво, что клиент выдает тупо "denied", потом оказалось, что конфиг, передаваемый извне, модифицируется и происходит перезапись этой переменной. blame показал, что сделано это в init коммите семенова. Если кто знает нфига это было сделано - welcome, а так выглядит как бажина..
