### PR TITLE
отправка данных в теле https запроса без принудительного декодирования

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -29,12 +29,10 @@ module.exports = typeof window == 'undefined' ? serverRequest : clientRequest;
 function serverRequest(conf) {
     var request = require('request');
 
-    if (!conf.body) {
-        if (conf.method && conf.method.toLowerCase() == 'post') {
-            conf.form = conf.data;
-        } else {
-            conf.qs = conf.data;
-        }
+    if (conf.method && conf.method.toLowerCase() == 'post') {
+        conf.body = conf.data;
+    } else {
+        conf.qs = conf.data;
     }
 
     _.defaults(conf, {


### PR DESCRIPTION
Если есть необходимость отправить данные просто в теле http запроса без декодирования в строку или упаковывания в форму, то в request это внезапно принудительно переписывается. Собственно добавлена проверка, что если body не пусто, то значит так надо...
