### PR TITLE
Add coveralls integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "devDependencies": {
     "chai": "~1.9.2",
     "gulp": "^3.8.11",
+    "gulp-coveralls": "^0.1.3",
     "gulp-istanbul": "^0.3.1",
     "gulp-jscs": "git://github.com/anru/gulp-jscs.git",
     "gulp-jsdoc": "^0.1.4",

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,7 @@ JavaScript фреймворк, позволяющий быстро и прост
 
 [![Join the chat at https://gitter.im/2gis/slot](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/2gis/slot?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://travis-ci.org/2gis/slot.svg?branch=master)](https://travis-ci.org/2gis/slot)
+[![Coverage Status](https://coveralls.io/repos/2gis/slot/badge.svg?branch=add%2Fcoveralls-integration)](https://coveralls.io/r/2gis/slot?branch=add%2Fcoveralls-integration)
 [![Dependency Status](https://gemnasium.com/2gis/slot.svg)](https://gemnasium.com/2gis/slot)
 
 ## Особенности

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ JavaScript фреймворк, позволяющий быстро и прост
 
 [![Join the chat at https://gitter.im/2gis/slot](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/2gis/slot?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://travis-ci.org/2gis/slot.svg?branch=master)](https://travis-ci.org/2gis/slot)
-[![Coverage Status](https://coveralls.io/repos/2gis/slot/badge.svg?branch=add%2Fcoveralls-integration)](https://coveralls.io/r/2gis/slot?branch=add%2Fcoveralls-integration)
+[![Coverage Status](https://coveralls.io/repos/2gis/slot/badge.svg?branch=master)](https://coveralls.io/r/2gis/slot?branch=master)
 [![Dependency Status](https://gemnasium.com/2gis/slot.svg)](https://gemnasium.com/2gis/slot)
 
 ## Особенности

--- a/tasks/coverage.js
+++ b/tasks/coverage.js
@@ -1,5 +1,6 @@
 var gulp = require('gulp');
 var istanbul = require('gulp-istanbul');
+var coveralls = require('gulp-coveralls');
 
 var coverable = [
     '*.js',
@@ -19,4 +20,9 @@ gulp.task('cover.report', function() {
             dir: './coverage',
             reporters: [ 'lcov', 'text']
         }));
+});
+
+gulp.task('cover.send', function() {
+    return gulp.src('./coverage/lcov.info')
+        .pipe(coveralls());
 });

--- a/tasks/hooks.js
+++ b/tasks/hooks.js
@@ -40,7 +40,7 @@ gulp.task('hooks.clear', function(cb) {
 gulp.task('hooks.run', function(cb) {
     runSequence(
         'cover.init',
-        'test',
+        'test.run',
         'cover.report',
         'lint',
         cb

--- a/tasks/hooks.js
+++ b/tasks/hooks.js
@@ -1,7 +1,7 @@
 var fs = require('fs');
 var gulp = require('gulp');
 var rimraf = require('rimraf');
-var runSequence = require('run-sequence');
+var runSequence = require('run-sequence').use(gulp);
 
 var HOOKS = 'git-hooks/hooks.sh';
 var PRE_PUSH = '.git/hooks/pre-push';

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -1,13 +1,14 @@
 var gulp = require('gulp');
 var mocha = require('gulp-mocha');
 var verbose = require('./utils/verbose');
+var runSequence = require('run-sequence');
 
 verbose.setMessages('test', {
     start: 'Запускаю тесты, тыдыщ',
     error: 'Тесты провалены, иди фиксить!',
     success: 'С тестами всё ок, молодцом!'
 });
-gulp.task('test', function() {
+gulp.task('test.run', function() {
     return gulp.src([
             'tests/unitTestConfig.js',
             '**/*.spec.js'
@@ -15,6 +16,20 @@ gulp.task('test', function() {
         .pipe(mocha({
             globals: ['DEBUG']
         }));
+});
+
+gulp.task('test', function(cb) {
+    if (process.env.TRAVIS) {
+        runSequence(
+            'cover.init',
+            'test.run',
+            'cover.report',
+            'cover.send',
+            cb
+        );
+    } else {
+        runSequence('test.run', cb);
+    }
 });
 
 gulp.task('default', ['test']);

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -1,7 +1,7 @@
 var gulp = require('gulp');
 var mocha = require('gulp-mocha');
 var verbose = require('./utils/verbose');
-var runSequence = require('run-sequence');
+var runSequence = require('run-sequence').use(gulp);
 
 verbose.setMessages('test', {
     start: 'Запускаю тесты, тыдыщ',


### PR DESCRIPTION
When tests runs in travic-ci environment -  start code coverage gathering and send it to coveralls.