### PR TITLE
fix/0-state-value-in-uri

### DIFF
--- a/components/appState/uri/pattern.js
+++ b/components/appState/uri/pattern.js
@@ -153,7 +153,7 @@ Pattern.prototype.inject = function(data, encode) {
     var self = this;
 
     var str = this.pattern.replace(paramReG, function(match, name) {
-        var value = data[name] || '';
+        var value = data[name] != null ? data[name] : '';
         var validator = self.validatorFor(name);
 
         if (validator && validator.toUrl) {


### PR DESCRIPTION
Нулевые (а также false) значения сейчас превращаются в пустую строку - это неправильно.
Теперь ограничения только на null и undefined.

https://github.com/2gis/slot/issues/164