### PR TITLE
fix/modules-filter

### DIFF
--- a/gulpy/pot.js
+++ b/gulpy/pot.js
@@ -14,19 +14,29 @@ module.exports = function(gulp) {
     var pot;
 
     /**
-     * Возвращает dirname - название каталога в котором лежит данный файл, basename - название самого файла без расширения
+     * Возвращает dirname - название каталога в котором лежит данный файл,
+     * basename - название самого файла без расширения
+     * moduleName - название папки вслед за папкой modules/
      * @param {string} filepath
-     * @returns {{dirname: String, basename: String}}
+     * @returns {{dirname: String, basename: String, [moduleName]: String}}
      */
     function getPathBases(filepath) {
         var dirname = path.dirname(filepath).split('/');
         dirname = dirname[dirname.length - 1];
         var basename = path.basename(filepath, path.extname(filepath));
+        var parts = /modules\/([a-zA-Z0-9-_]*)/.exec(filepath);
+        var moduleName = parts && parts[1];
 
-        return {
+        var out = {
             dirname: dirname,
             basename: basename
         };
+
+        if (moduleName) {
+            out.moduleName = moduleName;
+        }
+
+        return out;
     }
 
     /**
@@ -48,16 +58,17 @@ module.exports = function(gulp) {
     function modulesFilter(filepath) {
         if (!pot.flags) throw new Error("You must define flags to run modulesFilter");
         var bases = getPathBases(filepath);
+        var moduleName = bases.moduleName;
 
-        if (_.contains(pot.config.blackListModules, bases.basename)) {
+        if (moduleName && _.contains(pot.config.blackListModules, moduleName)) {
             return false;
         }
 
-        if (pot.config.whiteListModules && pot.config.whiteListModules.length && !_.contains(pot.config.whiteListModules, bases.basename)) {
+        if (moduleName && pot.config.whiteListModules && pot.config.whiteListModules.length && !_.contains(pot.config.whiteListModules, moduleName)) {
             return false;
         }
 
-        return bases.dirname == bases.basename;
+        return bases.dirname == bases.basename; // isSameFolder, работает не только на модули, но и на блоки и хелперы
     }
 
     function lib(name) {

--- a/tests/gulpy/pot.spec.js
+++ b/tests/gulpy/pot.spec.js
@@ -34,7 +34,7 @@ describe("Горшочек", function() {
                 blackListModules: ['firm', 'firmCard']
             };
 
-            var forBuild = pot.modulesFilter('firmCard/firmCard.js');
+            var forBuild = pot.modulesFilter('modules/firmCard/firmCard.js');
 
             assert(!forBuild, 'Если модуль в blackList, он не должен попадать в сборку ни при каких обстоятельствах');
         });
@@ -45,7 +45,7 @@ describe("Горшочек", function() {
                 blackListModules: ['firmCard', 'geoCard']
             };
 
-            var forBuild = pot.modulesFilter('firmCard/firmCard.js');
+            var forBuild = pot.modulesFilter('modules/firmCard/firmCard.js');
 
             assert(!forBuild, 'Если модуль в blackList, он не должен попадать в сборку ни при каких обстоятельствах');
         });
@@ -55,7 +55,7 @@ describe("Горшочек", function() {
                 whiteListModules: ['geoCard']
             };
 
-            var forBuild = pot.modulesFilter('firmCard/firmCard.js');
+            var forBuild = pot.modulesFilter('modules/firmCard/firmCard.js');
 
             assert(!forBuild, 'Если есть whiteList, но модуль не в нём, он не должен попадать в сборку');
         });


### PR DESCRIPTION
В фильтре была бага, точнее неучтенная потребность: нельзя было фильтровать файлы, которые не являются главными. Например, phone.less, ie8.less, print.less и пр. В результате они всегда собираются в релизную сборку.