### PR TITLE
plugins/ua: remove isMuseum

### DIFF
--- a/plugins/tests/ua.spec.js
+++ b/plugins/tests/ua.spec.js
@@ -1,10 +1,11 @@
 var assert = require('assert');
 
-describe("plugins.ua", function() {
+describe('plugins.ua', function() {
     it('Определение Яндекс.Браузера 1.7', function() {
         var ua = require('../ua.js')();
         var yandexUA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_4) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.172 YaBrowser/1.7.1364.17132 Safari/537.22";
         var result = ua(yandexUA);
-        assert.equal(result.isMuseum, false, 'Флаг isMuseum должен выставиться в false');
+        assert.equal(result.browser.name, 'Yandex', 'Имя браузера должно определиться как "Yandex"');
+        assert.equal(result.browser.major, 1, 'Мажорная версия браузера должна быть равна 1');
     });
 });

--- a/plugins/ua.js
+++ b/plugins/ua.js
@@ -46,29 +46,6 @@ module.exports = function(app) {
         return 'desktop';
     }
 
-    /**
-     * @private
-     * @returns {boolean}
-     */
-    function museum(ua) { // @TODO вынести в конфиг
-        var browser = ua.browser,
-            os = ua.os;
-
-        return (browser.name == 'Chrome' && browser.major < 21) ||
-            (browser.name == 'IE' && browser.major < 9) ||
-            (browser.name == 'Firefox' && browser.major < 29) ||
-            (browser.name == 'Mozilla') ||
-            (os.name == 'Windows' && os.version == '95') || // Если поставит нормальный браузер? Вы издеваетесь?
-            (browser.name == 'Opera' && browser.major < 12) ||
-            (browser.name == 'Opera Mini') ||
-            (browser.name == 'Safari' && os.name == 'Android' && browser.major < 4 && parseInt(os.version, 10) < 4) ||
-            (browser.name == 'Mobile Safari' && os.name == 'Android' && parseInt(os.version, 10) < 4) ||
-            (browser.name == 'Safari' && os.name == 'Android' && parseInt(os.version, 10) < 4) ||
-            (os.name == 'iOS' && browser.major < 7) ||
-            (os.name == 'Mac OS X' && browser.name == 'Safari' && browser.major < 6) || // Олдовая сафари
-            (os.name == 'Windows' && browser.name == 'Safari');
-    }
-
     function getUAFromRegistry() {
         return app.registry.has('ua') ? app.registry.get('ua').ua : '';
     }
@@ -98,7 +75,6 @@ module.exports = function(app) {
         };
 
         _.extend(result, {
-            isMuseum: museum(result),
             isDesktop: isDesktop,
             isPhone: isPhone,
             isTablet: isTablet,


### PR DESCRIPTION
Убираем флаг `ua().isMuseum` из фреймворка, конечные приложения должны сами проставлять такие специфичные флаги