### PR TITLE
remove pot.platform.museum

### DIFF
--- a/gulpy/ext/platform.js
+++ b/gulpy/ext/platform.js
@@ -6,7 +6,7 @@
 var _ = require('lodash');
 
 module.exports = function(pot) {
-    var names = ['phone', 'tablet', 'ie8', 'ie9', 'museum'];
+    var names = ['phone', 'tablet', 'ie8', 'ie9'];
     var platform = {};
 
     names.map(function(name) {


### PR DESCRIPTION
Убрана поддержка новой платформы: музея (добавлена тут https://github.com/2gis/slot/pull/200).