### PR TITLE
Add ESLint tool to the project

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,9 @@
+# node_modules ignored by default
+
+cli/templates/
+coverage/
+i18n/tasks/extractors/
+
+# remove and fix after (or during) test refactoring
+tests/
+**/tests/

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,14 @@
+{
+    "rules": {
+        "indent": [2, 4],
+        "quotes": [2, "single"],
+        "linebreak-style": [2, "unix"],
+        "semi": [2, "always"]
+    },
+    "env": {
+        "es6": true,
+        "node": true,
+        "browser": true
+    },
+    "extends": "eslint:recommended"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules
 .DS_Store
 npm-debug.log
 *.swp
+.eslintcache

--- a/cli/slot.js
+++ b/cli/slot.js
@@ -6,7 +6,6 @@ var _ = require('lodash');
 var path = require('path');
 var async = require('async');
 var extfs = require('extfs');
-var colors = require('colors');
 var glob = require('glob').sync;
 var program = require('commander');
 

--- a/components/stateTracker.js
+++ b/components/stateTracker.js
@@ -6,7 +6,6 @@
 var _ = require('lodash');
 var EventEmitter = require('events').EventEmitter;
 var inherits = require('inherits');
-var env = require('slot/env');
 
 module.exports = StateTracker;
 function StateTracker(app) {

--- a/config.js
+++ b/config.js
@@ -3,7 +3,6 @@
  */
 
 var env = require('./env');
-var _ = require('lodash');
 
 var cfg = env.getConfig();
 module.exports = cfg;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,13 +1,16 @@
-
 var gulp = require('gulp');
 var requireDir = require('require-dir');
+var colors = require('colors/safe');
 
 requireDir('./tasks');
 
 var exitCode = 0;
 
-function errHandler() {
+function errHandler(msg) {
     exitCode = 1;
+    if (msg) {
+        console.log(colors.bgRed(msg));
+    }
     process.stdout.write('\u0007'); // beep sound if possible
 }
 

--- a/gulpy/ext/watch.js
+++ b/gulpy/ext/watch.js
@@ -1,6 +1,4 @@
-
 var events = require('events');
-var glob = require('flat-glob').sync;
 var globule = require('globule');
 var chokidar = require('chokidar');
 

--- a/gulpy/lib/changedStream.js
+++ b/gulpy/lib/changedStream.js
@@ -1,4 +1,3 @@
-var _ = require('lodash');
 var fs = require('fs');
 var path = require('path');
 var glob = require('flat-glob').sync;

--- a/gulpy/plugins/scs/checker.js
+++ b/gulpy/plugins/scs/checker.js
@@ -74,7 +74,7 @@ module.exports = function(filename, contents, options) {
             if (start2 == -1) start2 = 1 / 0;
             if (start3 == -1) start3 = 1 / 0;
 
-            start = Math.min(start1, start2, start3);
+            var start = Math.min(start1, start2, start3);
 
             if (start != -1) {
                 line = line.substr(0, start);

--- a/moduleConstructor.js
+++ b/moduleConstructor.js
@@ -1,6 +1,5 @@
 var _ = require('lodash');
 var namer = require('./lib/namer');
-var env = require('./env');
 
 /**
  * Конструктор модулей. Создаёт инстанс модуля, обвешивая его конфиг всякими методами.

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "bin": {
     "slot": "./cli/slot.js"
   },
-  "directories":{
+  "directories": {
     "doc": "docs"
   },
   "dependencies": {
@@ -85,11 +85,14 @@
   },
   "scripts": {
     "test": "gulp test",
+    "lint": "npm run -s lint:hook; exit 0",
+    "lint:hook": "eslint --color --cache .",
     "postinstall": "node ./scripts/postinstall.js"
   },
   "license": "BSD-2-Clause",
   "devDependencies": {
     "chai": "~1.9.2",
+    "eslint": "^1.6.0",
     "gulp": "^3.8.11",
     "gulp-coveralls": "^0.1.3",
     "gulp-istanbul": "^0.3.1",

--- a/plugins/fpsMeter.js
+++ b/plugins/fpsMeter.js
@@ -93,8 +93,7 @@ module.exports = function(app) {
         end: function(percentile) {
             if (!app.isClient) return;
 
-            var str = '',
-                norm = [],
+            var norm = [],
                 sum = 0;
 
             if (!getRaf()) return;

--- a/slot/templateHelpers.js
+++ b/slot/templateHelpers.js
@@ -4,7 +4,6 @@
  */
 
 var _ = require('lodash');
-var env = require('../env');
 var namer = require('../lib/namer');
 
 module.exports = function(slot, templateEngine) {

--- a/tasks/hooks.js
+++ b/tasks/hooks.js
@@ -43,6 +43,7 @@ gulp.task('hooks.run', function(cb) {
         'test.run',
         'cover.report',
         'lint',
+        // 'eslint',
         cb
     );
 });

--- a/tasks/lint.js
+++ b/tasks/lint.js
@@ -1,16 +1,16 @@
-var _ = require('lodash');
 var gulp = require('gulp');
 var jscs = require('gulp-jscs');
 var jshint = require('gulp-jshint');
 var through = require('through2');
 var verbose = require('./utils/verbose');
 var runSequence = require('run-sequence');
+var exec = require('child_process').exec;
 
 /**
- * Проверяет не произошла ли ошибка при проверка файла
+ * Проверяет не произошла ли ошибка при проверке файла
  * Если найдена ошибка, то бросается событие 'tl.fail'
  *
- * @param type
+ * @param {string} type
  * @returns {*}
  */
 function check(type) {
@@ -55,4 +55,15 @@ gulp.task('lint.jshint', function() {
 
 gulp.task('lint', function(cb) {
     runSequence('lint.jscs', 'lint.jshint', cb);
+});
+
+gulp.task('eslint', function(cb) {
+    exec('npm run -s lint:hook', function(err, stdout) {
+        if (err) {
+            console.log(stdout);
+            gulp.emit('tl.fail', 'ESlint failed');
+        }
+
+        cb();
+    });
 });

--- a/tasks/utils/verbose.js
+++ b/tasks/utils/verbose.js
@@ -23,7 +23,7 @@ exports.setMessages = function(name, meggases) {
 };
 
 /**
- * Вклюсить режим показа текстов
+ * Включить режим показа текстов
  */
 exports.enable = function() {
     gulp.on('task_start', function(task) {


### PR DESCRIPTION
Eslint added.

Now it is disabled untill correct config are created and fixed all errors.

But it can be used manually by running `npm run lint` ol `gulp eslint`.
Feature added as npm script due to some reasons:
1.  [NPM it is already powerfull build tool](http://blog.keithcirkel.co.uk/how-to-use-npm-as-a-build-tool/)
2. `gulp-eslint` doesn't support usefull '--cache' flag

:warning: It is comfortable to review separate commits.