### PR TITLE
add functional to save cooke at server side

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -707,6 +707,7 @@ Application.prototype.cookie = function(key, value, params) {
                 params.expires = new Date(Date.now() + params.expires * 24 * 60 * 60 * 1000);
             }
 
+            this.cookies[key] = value;
             this.emit('cookie', key, value, params);
         } else {
             value = this.cookies[key]; // Извлечь значение куки key на сервере из запроса клиента

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slot",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "homepage": "https://github.com/2gis/slot",
   "repository": "git@github.com:2gis/slot.git",
   "bugs": "https://github.com/2gis/slot/issues",

--- a/tests/app.spec.js
+++ b/tests/app.spec.js
@@ -63,6 +63,8 @@ describe('app', function() {
             };
             appIntance.init(data, _.noop);
             assert(appIntance.cookie('a') == '1', 'Переданные cookie должны были записаться');
+            appIntance.cookie('b', '2');
+            assert(appIntance.cookie('b') == '2', 'Установленная cookie должна была записаться');
         });
 
         it('Вызывается callback после инициализации', function() {


### PR DESCRIPTION
На данный момент на стороне сервера куки работают так:
на этапе инита приложения все куки, пришедшие с запросом, складываются в объект cookies и, в последствии, при обращении к какой либо из кук из этого объекта же и достаются. В случае же когда происходит попытка записать новую куку пользователю, эмитится событие 'cookie', которое должно быть обработано. Обработка в случае online4 заключается в том, что мы пробрасываем куку на клиент. Однако если в последствии на сервере обратиться к только что переданной клиенту куке, то она не будет найдена, так как не была добавлена в объект, из которого происходит считывание. 
Собственно, данный PR призван это исправить.