### PR TITLE
Ignore node_modules from test runner glob. Closes #220

### DIFF
--- a/tasks/lint.js
+++ b/tasks/lint.js
@@ -26,7 +26,7 @@ var files = [
     '**/*.js',
     '!docs/**/*.js',
     '!smokesignals/index.js',
-    '!**/node_modules/**/*',
+    '!node_modules/**',
     '!coverage/**/*.js',
     '!cli/templates/**/*.js'
 ];

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -11,8 +11,11 @@ verbose.setMessages('test', {
 gulp.task('test.run', function() {
     return gulp.src([
             'tests/unitTestConfig.js',
-            '**/*.spec.js'
-        ], {read: false})
+            '**/*.spec.js',
+            '!node_modules/**'
+        ], {
+            read: false
+        })
         .pipe(mocha({
             globals: ['DEBUG']
         }));


### PR DESCRIPTION
Exclude `node_modules` from test runner glob

Closes #220 
