### PR TITLE
Disable JSDoc validation by jscs

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -61,10 +61,16 @@
     "disallowMixedSpacesAndTabs": true,
     "disallowTrailingWhitespace": true,
     "disallowKeywordsOnNewLine": ["else"],
-    "validateJSDoc": {
-        //"checkParamNames": true,
-        //"checkRedundantParams": true,
-        "requireParamTypes": false
-    },
+// Тemporarily disable
+//    "jsDoc": {
+//        "checkParamExistence": true,
+//        "checkParamNames": true,
+//        "checkRedundantParams": true
+//        "requireParamTypes": true,
+//        "checkReturnTypes": true,
+//        "checkRedundantReturns": true,
+//        "requireReturnTypes": true
+//        "requireNewlineAfterDescription": true
+//    },
     "requireSpaceAfterLineComment": true
 }


### PR DESCRIPTION
Fix jsDoc rule name. Add some rules and disable it temporarely because it's too many errors found.

Closes #222