### PR TITLE
Update async to version 1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "doc": "docs"
   },
   "dependencies": {
-    "async": "^0.9.0",
+    "async": "^1.5.0",
     "async.emitter": "^1.1.0",
     "chokidar": "^1.0.0-rc5",
     "colors": "^1.0.3",


### PR DESCRIPTION
Just updating to a new version of the library. As [async changelog](https://github.com/caolan/async/blob/master/CHANGELOG.md) says there is no breaking changes.