### PR TITLE
fix injectors for sourcemapped code

### DIFF
--- a/gulpy/lib/injector.js
+++ b/gulpy/lib/injector.js
@@ -8,6 +8,7 @@ var through = require('through2');
  */
 function getInjectCode(src) {
     var injector = require('../../lib/injector');
+
     var args = injector.getArgs(src.toString());
     var writeInject = args && args.length && args.some(function(arg) {
         return arg.charAt(0) == '$';
@@ -15,6 +16,22 @@ function getInjectCode(src) {
     if (writeInject) {
         return 'module.exports._args = ' + JSON.stringify(args) + ';';
     }
+}
+
+/**
+ * Добавление аннотаций перед sourcemap
+ * Нужно на случай, если аннотируемый код уже был пропущен
+ * через некоторый препроцессор, генерирующий сайтмапы (babel, tsc, etc)
+ */
+function injectBeforeSourcemap(code, injectText) {
+    if (!injectText) {
+        return code;
+    }
+
+    var sourcemapSeparator = '//# sourceMappingURL=';
+    code = code.split(sourcemapSeparator);
+    code[0] += injectText + '\n';
+    return code.join(sourcemapSeparator);
 }
 
 /**
@@ -26,15 +43,14 @@ function injectStream() {
 
     return through(function(chunk, enc, callback) {
         buf += chunk.toString();
-        callback(null, chunk);
+        callback();
     }, function(done) {
-        var injectText = getInjectCode(buf);
-        if (injectText) {
-            this.push(injectText);
-        }
+        this.push(injectBeforeSourcemap(buf, getInjectCode(buf)));
+        buf = '';
         done();
     });
 }
 
 exports.getInjectCode = getInjectCode;
 exports.injectStream = injectStream;
+


### PR DESCRIPTION
We should add DI annotations before any sourcemaps. or annotations will be considered as a part of sourcemap and will be cut in downstream.
Pretty ugly hack, but should not break anything.