### PR TITLE
add morphdom & rework module kill/dispose

### DIFF
--- a/app/clientApp.js
+++ b/app/clientApp.js
@@ -9,6 +9,7 @@ var Application = require('./index');
 var namer = require('../lib/namer');
 var defer = require('../lib/defer');
 var inherits = require('inherits');
+var morphdom = require('morphdom');
 require('./jquery.mod');
 
 module.exports = ClientApplication;
@@ -115,6 +116,29 @@ ClientApplication.prototype.rerender = function(moduleId) {
     $(moduleBlockId(moduleId)).replaceWith(html);
 
     this.bindEvents(moduleId);
+};
+
+
+/**
+ * Morphs current module DOM to new rendered html.
+ * Like .rerender(), but without killing node and
+ * unbinding/binding events.
+ *
+ * @param {string} moduleId
+ */
+ClientApplication.prototype.morph = function(moduleId) {
+    var blockNode = $(moduleBlockId(moduleId))[0];
+
+    if (blockNode) {
+        var descriptor = this.getModuleDescriptorById(moduleId);
+        var html = descriptor.instance.render();
+
+        morphdom(blockNode, html, {
+            getNodeKey: function() {
+                return null;
+            }
+        });
+    }
 };
 
 /**

--- a/app/index.js
+++ b/app/index.js
@@ -533,16 +533,16 @@ Application.prototype.killModule = function(moduleId) {
         var parent = this._moduleDescriptors[parentId];
         var childrenOfParent = parent.slot.modules[moduleInstance.type];
 
-        if (_.isObject(childrenOfParent)) {
-            delete parent.slot.modules[moduleInstance.type];
-        } else if (_.isArray(childrenOfParent)) {
+        if (_.isArray(childrenOfParent)) {
             _.remove(childrenOfParent, function(child) { // Удаляем из массива элемент с таким id-шником
-                return child.id() == moduleId;
+                return child.id == moduleId;
             });
 
             if (childrenOfParent.length == 0) {
                 delete parent.slot.modules[moduleInstance.type];
             }
+        } else {
+            delete parent.slot.modules[moduleInstance.type];
         }
     }
 
@@ -556,7 +556,7 @@ Application.prototype.killModule = function(moduleId) {
  * Модуль окончательно удаляется (из дом-дерева и дерева модулей)
  * @param moduleId
  */
-Application.prototype.removeModule = function(moduleId) {
+Application.prototype.removeModule = function(moduleId, options) {
     var descriptor = this._moduleDescriptors[moduleId];
     if (!descriptor) return;
 
@@ -566,7 +566,7 @@ Application.prototype.removeModule = function(moduleId) {
 
     if (moduleConf.dispose) moduleConf.dispose();
 
-    if (this.isClient) {
+    if (this.isClient && !_.get(options, 'keepDOM')) {
         slot.block().remove();
     }
     slot.stage = slot.STAGE_DISPOSED;
@@ -579,14 +579,13 @@ Application.prototype.removeModule = function(moduleId) {
 
     if (parentId) {
         this._moduleDescriptors[parentId].children = _.without(this._moduleDescriptors[parentId].children, moduleId);
-        delete this._moduleDescriptors[parentId].slot.modules[descriptor.type];
     }
     delete this._moduleDescriptors[moduleId];
 };
 
-Application.prototype.disposeModule = function(moduleId) {
+Application.prototype.disposeModule = function(moduleId, options) {
     this.killModule(moduleId);
-    this.removeModule(moduleId);
+    this.removeModule(moduleId, options);
 };
 
 /**

--- a/app/jquery.mod.js
+++ b/app/jquery.mod.js
@@ -30,9 +30,7 @@ if (typeof $ != 'undefined') {
         // нет модификаторов для установки -> просто возращаем mods первого элемента
         if (!mods) {
             // если mods не установлен, парсим и устанавливаем его из className
-            return firstEl.mods || (
-                    firstEl.mods = namer.parseMods(firstEl.className)
-                );
+            return namer.parseMods(firstEl.className);
         }
 
         this.each(function(index, el) {
@@ -76,7 +74,7 @@ if (typeof $ != 'undefined') {
             el.className = classNames.join(' ');
         });
 
-        return firstEl.mods;
+        return namer.parseMods(firstEl.className);
     };
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slot",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "homepage": "https://github.com/2gis/slot",
   "repository": "git@github.com:2gis/slot.git",
   "bugs": "https://github.com/2gis/slot/issues",
@@ -71,6 +71,7 @@
     "jquery-deferred": "~0.3.0",
     "lodash": "^3.10.1",
     "mkdirp": "~0.5.0",
+    "morphdom": "^1.1.2",
     "ncp": "^2.0.0",
     "po2json": "0.2.3",
     "request": "~2.27.0",

--- a/slot/index.js
+++ b/slot/index.js
@@ -598,6 +598,7 @@ if (env.isClient) {
      * @memberof module:Slot
      */
     Slot.prototype.rerender = proxy('rerender', true);
+    Slot.prototype.morph = proxy('morph', true);
     Slot.prototype.bindEvents = proxy('bindEvents', true);
     Slot.prototype.unbindEvents = proxy('unbindEvents', true);
 }


### PR DESCRIPTION
upd:

1. Теперь есть метод `slot.morph()`, который заменяет старый html новым html посредством morphdom;

2. Теперь у `slot.dispose()` есть параметр options, который позволяет полностью убить модуль, но оставить его DOM: `slot.dispose({keepDOM: true})`;

3. Поправил удаление модулей из slot.modules — теперь удаляется только нужный модуль, а не все модули этого типа;

4. Убрал кеширование модификаторов на дом-нодах