### PR TITLE
Pass unbindEvents hook to module config

### DIFF
--- a/app/clientApp.js
+++ b/app/clientApp.js
@@ -204,6 +204,8 @@ ClientApplication.prototype.processEvents = function(moduleId, elementName, on) 
     if (on) {
         descriptor.instance.clientInit();
         descriptor.instance.bind();
+    } else {
+        descriptor.instance.unbind();
     }
 
     // Рекурсивно вызываем функцию для всех дочерних элементов

--- a/moduleConstructor.js
+++ b/moduleConstructor.js
@@ -85,6 +85,12 @@ module.exports = function(app, moduleConf, slot) {
             }
         },
 
+        unbind: function() {
+            if (moduleConf.unbind) {
+                moduleConf.unbind();
+            }
+        },
+
         changeState: function() {
             if (moduleConf.changeState) {
                 moduleConf.changeState.apply(moduleConf, arguments);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slot",
-  "version": "0.13.11",
+  "version": "0.13.12",
   "homepage": "https://github.com/2gis/slot",
   "repository": "git@github.com:2gis/slot.git",
   "bugs": "https://github.com/2gis/slot/issues",


### PR DESCRIPTION
https://jira.2gis.ru/browse/ONLINE-9483

Иногда возникает ситуация, когда нужно ручками подписаться на какие-то событие в DOM. Традиционно в слоте это делается в clinetInit(), а отписка происходит в dispose();
С dumb-модулями есть проблема. Возникла ситуация, когда нужно подписываться на события DOM ноды не всегда, а по условию, зависящему от стейта. Удобнее всего это делать в методе bind(), который срабатывает на каждый ре-рендер глупого модуля. Использовать dispose() для снятия подписки на событие в таком случае не получается, потому что он не вызывается, поэтому нужен хук в конфиге модуля, по которому можно чистить все подписки перед каждым обновлением глупого модуля.

Пример использования:
```
...
bind() {
   if (state.edit || state.showShare || state.showDeleteDialog) {
       document.addEventListener('click', onDocumentClick, true);
   }
},
unbind() {
   document.removeEventListener('click', onDocumentClick, true);
},
...
```