### PR TITLE
appstate optimization

### DIFF
--- a/components/appState/stateConf.js
+++ b/components/appState/stateConf.js
@@ -276,7 +276,7 @@ StateConf.prototype.permalink = function(type, params, domain, strict) {
     }
 
     var uri = lastPattern.inject(params);
-    return (domain || '') + helpers.transform(uri, this);
+    return (domain || '') + uri;
 };
 
 module.exports = StateConf;

--- a/components/appState/uri/helpers.js
+++ b/components/appState/uri/helpers.js
@@ -24,25 +24,3 @@ exports.makeAlias = function(uriPart, params, alias) {
     };
 };
 
-/**
- * Transorm uri: take uri, parse it, create new uri
- * Use if you change uri format and support old and new formats
- *
- * @param uri - start uri
- * @param stateConf
- * @returns {string} - transformed uri
- */
-exports.transform = function(uri, stateConf) {
-    var slugEntries = parser.parse(stateConf.patterns, uri, [], stateConf.get('queryParamName'));
-    var state = {};
-    stateConf.invokeInjectors(slugEntries, state);
-
-    // Поскольку в notParsed может быть всё, что угодно, то приведем его в порядок
-    var cleanNotParsed = _.compact(slugEntries.notParsed.join('/').split('/')).join('/');
-    var newUri = _.compact([cleanNotParsed, resolver(stateConf, state)]).join('/');
-    if (newUri.charAt(0) != '/') {
-        return '/' + newUri;
-    }
-    return newUri;
-};
-

--- a/components/appState/uri/parser.js
+++ b/components/appState/uri/parser.js
@@ -1,6 +1,6 @@
 
 var _ = require('lodash');
-var urlParse = require('url-parse');
+var urlParse = require('url').parse;
 var serializer = require('./serializer');
 
 /**

--- a/components/appState/uri/pattern.js
+++ b/components/appState/uri/pattern.js
@@ -1,10 +1,8 @@
 
 var _ = require('lodash');
-var stuff = require('../../../lib/stuff');
 var SlugEntry = require('./slugEntry');
 
-var paramReG = /:(\w+)/g,
-    paramReN = /:(\w+)/;
+var paramReG = /:(\w+)/g;
 
 var serializer = require('./serializer');
 
@@ -14,15 +12,25 @@ var compileCache = {};
  * @returns {RegExp} Регесп для разбора готовой строки, но не паттерна!
  */
 function compile(pattern) {
-    if (!(pattern in compileCache)) {
-        var parts = pattern.split('/'),
-            reStr = stuff.escapeRegExp(parts[0]) + (parts.length > 1 ? '/' : '') + parts.slice(1).join('/');
-        reStr = reStr.replace(paramReG, '([^\/]+)');
-
-        compileCache[pattern] = new RegExp(reStr);
+    var compiledPattern = compileCache[pattern];
+    if (!compiledPattern) {
+        var reStr = _.escapeRegExp(pattern).replace(paramReG, '([^\/]+)');
+        compiledPattern = new RegExp(reStr);
+        compileCache[pattern] = compiledPattern;
     }
+    return compiledPattern;
+}
 
-    return compileCache[pattern];
+/**
+ * @returns {string} Инкодит слеши в queryString'е
+ */
+function encodeQuerySlashes(pattern) {
+    var queryIndex = pattern.indexOf('?');
+    if (queryIndex != -1) {
+        var queryString = pattern.slice(queryIndex);
+        return pattern.slice(0, queryIndex) + serializer.encodeSlashes(queryString);
+    }
+    return pattern;
 }
 
 /**
@@ -32,30 +40,19 @@ function compile(pattern) {
  * @constructor
  */
 function Pattern(pattern, validators) {
+    pattern = encodeQuerySlashes(pattern);
+
     this.pattern = pattern;
+
+    this.slug = pattern.split('/')[0];
+
+    this.validators = validators;
 
     this.patternRe = compile(pattern);
 
-    var parts = pattern.split('/');
-    this.slug = parts[0];
-    this.validators = validators;
-    var params = [];
-
-    for (var i = 1, len = parts.length; i < len; i++) {
-        var paramStr = parts[i];
-        var matchList = paramStr.match(paramReG);
-        if (!matchList) continue; // its just text, skip
-
-        _.each(matchList, function(paramDef) {
-            var match = paramReN.exec(paramDef);
-
-            var name = match[1];
-
-            params.push(name);
-        });
-    }
-
-    this.params = params;
+    this.params = _.map(pattern.match(paramReG), function(param) {
+        return param.slice(1);
+    });
 }
 
 /**
@@ -79,21 +76,21 @@ Pattern.prototype.checkData = function(data) {
     var errorKeys = [];
 
     _.each(this.params, function(name) {
-       if (name in data) {
-           var value = data[name];
+        if (name in data) {
+            var value = data[name];
 
-           var validator = this.validatorFor(name);
+            var validator = this.validatorFor(name);
 
-           if (validator && validator.toUrl) {
-               value = validator.toUrl(value);
-           }
+            if (validator && validator.toUrl) {
+                value = validator.toUrl(value);
+            }
 
-           if (validator && !validator(value)) {
-               errorKeys.push(name);
-           }
-       } else {
-           errorKeys.push(name); // key is missing
-       }
+            if (validator && !validator(value)) {
+                errorKeys.push(name);
+            }
+        } else {
+            errorKeys.push(name); // key is missing
+        }
     }, this);
 
     return errorKeys.length ? errorKeys : null;
@@ -152,7 +149,7 @@ Pattern.prototype.inject = function(data, encode) {
     encode = encode == null ? true : encode;
     var self = this;
 
-    var str = this.pattern.replace(paramReG, function(match, name) {
+    return this.pattern.replace(paramReG, function(match, name) {
         var value = data[name] != null ? data[name] : '';
         var validator = self.validatorFor(name);
 
@@ -161,11 +158,10 @@ Pattern.prototype.inject = function(data, encode) {
         }
 
         if (encode) {
-            value = serializer.encodeSlashes(value);
+            value = serializer.encodeComponent(value);
         }
         return value;
     });
-    return encode ? serializer.encode(str) : str;
 };
 
 module.exports = Pattern;

--- a/components/stateTracker.js
+++ b/components/stateTracker.js
@@ -29,7 +29,7 @@ StateTracker.prototype.resolveURL = function(url) {
     url = url || document.location.pathname;
 
     if (!history.emulate) { // если у нас не hash url, добавляем query string чтобы не потерялась
-        url = stuff.extendQuery(location.href, url, this.forcedRenewParam);
+        url = stuff.extendQuery(url, location.href, this.forcedRenewParam);
     }
 
     return url;

--- a/lib/expandString.js
+++ b/lib/expandString.js
@@ -4,20 +4,29 @@ var _ = require('lodash');
 
 var optionalRe = /\[([^\]]+)\]/;
 
-function stripSlashes(str) {
-    return str.replace(/\/+$/, '').replace(/^\/+/, '');
-}
-
-function joinParts(parts) {
-    return _.chain(parts)
-        .map(stripSlashes)
-        .compact()
-        .value()
-        .join('/');
-}
-
 function replaceMatch(str, match, value) {
-    return joinParts([str.substring(0, match.index), value, str.substr(match.index + match[0].length)]);
+    return str.slice(0, match.index) + value + str.slice(match.index + match[0].length);
+}
+
+function expandFirst(str) {
+    var match = str.match(optionalRe);
+    if (!match) {
+        return [str];
+    } else {
+        return [
+            replaceMatch(str, match, match[1]),
+            replaceMatch(str, match, '')
+        ];
+    }
+}
+
+function doExpand(str) {
+    var parts = expandFirst(str);
+    if (parts.length > 1) {
+        return _.flatten(_.map(parts, doExpand));
+    } else {
+        return parts;
+    }
 }
 
 /**
@@ -25,31 +34,4 @@ function replaceMatch(str, match, value) {
  * @param str
  * @returns {String[]}
  */
-function expand(str) {
-    var prefix = str.charAt(0) == '/' ? '/' : '';
-
-    function expandFirst(str) {
-        var match = str.match(optionalRe);
-        if (!match) {
-            return [str];
-        } else {
-            return [
-                prefix + replaceMatch(str, match, match[1]),
-                prefix + replaceMatch(str, match, '')
-            ];
-        }
-    }
-
-    function doExpand(str) {
-        var parts = expandFirst(str);
-        if (parts.length > 1) {
-            return _.flatten(_.map(parts, doExpand));
-        } else {
-            return parts;
-        }
-    }
-
-    return doExpand(str);
-}
-
-module.exports = expand;
+module.exports = doExpand;

--- a/lib/stuff.js
+++ b/lib/stuff.js
@@ -2,6 +2,7 @@
  * @module stuff
  */
 
+var querystring = require('querystring');
 var _ = require('lodash');
 
 /**
@@ -46,16 +47,16 @@ function logToChannel(channel, type, args) {
     }
 }
 
-    /**
-     * Форматирует строку.
-     *
-     * @example
-     * _.format('Hello %1 and %2', 'Vasya', 'Petya'); // => 'Hello Vasya and Petya'
-     *
-     * @param {string} str - Форматируемая строка.
-     * @param {...Array} values - Значения для форматирования.
-     * @returns {string} Отформатированная строка.
-     */
+/**
+ * Форматирует строку.
+ *
+ * @example
+ * _.format('Hello %1 and %2', 'Vasya', 'Petya'); // => 'Hello Vasya and Petya'
+ *
+ * @param {string} str - Форматируемая строка.
+ * @param {...Array} values - Значения для форматирования.
+ * @returns {string} Отформатированная строка.
+ */
 exports.format = function(str) {
     var values =  arguments;
 
@@ -63,10 +64,6 @@ exports.format = function(str) {
         num = parseInt(num, 10);
         return values[num];
     });
-};
-
-exports.escapeRegExp = function(str) {
-    return str.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1");
 };
 
 /**
@@ -182,31 +179,35 @@ exports.uri2state = function(uri) {
 /**
  * Extend query string
  *
- * @param [String] urlOld
- * @param [String] urlNew
+ * @param [String] newUrl
+ * @param [String|Object] oldUrl
  * @returns {String}
  */
-exports.extendQuery = function(urlOld, urlNew, forcedRenewParam) {
-    if (!urlOld && !urlNew) return '';
-    if (!urlOld) return urlNew;
-    if (!urlNew) return urlOld;
+exports.extendQuery = function(newUrl, oldUrl, forcedRenewParam) {
+    if (_.isEmpty(oldUrl) && _.isEmpty(newUrl)) return '';
+    if (_.isEmpty(oldUrl)) return newUrl;
+    if (_.isEmpty(newUrl)) return oldUrl;
 
-    var urlParse = require('url-parse');
-    var newLocation = urlParse(urlNew, true);
-    var currentLocation = urlParse(urlOld, true);
+    var newQueryIndex = newUrl.indexOf('?');
+    var newQuery = newQueryIndex != -1 ? newUrl.slice(newQueryIndex + 1) : '';
+    var newQueryParsed = newQuery ? querystring.parse(newQuery) : {};
+
+    var oldQueryParsed;
+    if (_.isString(oldUrl)) {
+        var oldQueryIndex = oldUrl.indexOf('?');
+        var oldQuery = oldQueryIndex != -1 ? oldUrl.slice(oldQueryIndex + 1) : '';
+        oldQueryParsed = oldQuery ? querystring.parse(oldQuery) : {};
+    } else {
+        oldQueryParsed = oldUrl;
+    }
+
     if (forcedRenewParam) {
-        delete currentLocation.query[forcedRenewParam];
+        delete oldQueryParsed[forcedRenewParam];
     }
 
-    if (!newLocation.protocol) { // some of these params can be absent
-        newLocation.set('protocol', currentLocation.protocol);
-    }
-    if (!newLocation.host) {
-        newLocation.set('host', currentLocation.host);
-    }
-    if (!newLocation.hostname) {
-        newLocation.set('hostname', currentLocation.hostname);
-    }
+    var resQueryParsed = _.extend(oldQueryParsed, newQueryParsed);
+    var resBase = newQueryIndex != -1 ? newUrl.slice(0, newQueryIndex) : newUrl;
+    var resQuery = _.isEmpty(resQueryParsed) ? '' : '?' + querystring.stringify(resQueryParsed);
 
-    return newLocation.set('query', _.extend(currentLocation.query, newLocation.query)).toString();
+    return resBase + resQuery;
 };

--- a/lib/tests/expandString.spec.js
+++ b/lib/tests/expandString.spec.js
@@ -10,21 +10,21 @@ describe('expandString', function() {
     });
 
     it('не должен терять слэши в начале строки', function() {
-        assert.deepEqual(expand('/city/:city/[page/:page]'), [
+        assert.deepEqual(expand('/city/:city[/page/:page]'), [
             '/city/:city/page/:page',
             '/city/:city'
         ]);
     });
 
     it('очень простой пример', function() {
-        assert.deepEqual(expand('foo/[:id]'), [
+        assert.deepEqual(expand('foo[/:id]'), [
             'foo/:id',
             'foo'
         ]);
     });
 
     it("простой пример", function() {
-        assert.deepEqual(expand('foo/[:ab]/[firms/:id]'), [
+        assert.deepEqual(expand('foo[/:ab][/firms/:id]'), [
             'foo/:ab/firms/:id',
             'foo/:ab',
             'foo/firms/:id',
@@ -33,7 +33,7 @@ describe('expandString', function() {
     });
 
     it('слэш внутри опциона (нежелательно, но работать должно)', function() {
-        assert.deepEqual(expand('foo/[:ab/][firms/:id]'), [
+        assert.deepEqual(expand('foo[/:ab][/firms/:id]'), [
             'foo/:ab/firms/:id',
             'foo/:ab',
             'foo/firms/:id',
@@ -42,7 +42,7 @@ describe('expandString', function() {
     });
 
     it('пример из трех опционов', function() {
-        assert.deepEqual(expand('foo/[id/:id]/[ab/:page]/[filters/:text]'), [
+        assert.deepEqual(expand('foo[/id/:id][/ab/:page][/filters/:text]'), [
             'foo/id/:id/ab/:page/filters/:text',
             'foo/id/:id/ab/:page',
             'foo/id/:id/filters/:text',

--- a/lib/tests/stuff.spec.js
+++ b/lib/tests/stuff.spec.js
@@ -10,35 +10,35 @@ describe('stuff', function() {
             var newUrl = 'https://www.search.ru/?q=beer';
             var oldUrl = 'https://www.search.ru/';
 
-            assert.equal(extendQuery(oldUrl, newUrl), 'https://www.search.ru/?q=beer');
+            assert.equal(extendQuery(newUrl, oldUrl), 'https://www.search.ru/?q=beer');
         });
 
         it('если параметров нет в новом УРЛе, то они остаются от старого', function() {
             var newUrl = 'https://www.search.ru/?q=beer';
             var oldUrl = 'https://www.search.ru/?r=whiskey';
 
-            assert.equal(extendQuery(oldUrl, newUrl), 'https://www.search.ru/?r=whiskey&q=beer');
+            assert.equal(extendQuery(newUrl, oldUrl), 'https://www.search.ru/?r=whiskey&q=beer');
         });
 
         it('если параметр есть и там, и там, берется новое значение', function() {
             var newUrl = 'https://www.search.ru/?q=beer';
             var oldUrl = 'https://www.search.ru/?q=whiskey';
 
-            assert.equal(extendQuery(oldUrl, newUrl), 'https://www.search.ru/?q=beer');
+            assert.equal(extendQuery(newUrl, oldUrl), 'https://www.search.ru/?q=beer');
         });
 
         it('прочие части нового УРЛа остаются неизменными', function() {
             var newUrl = 'https://www.search.ru/?q=beer';
             var oldUrl = 'http://another.ru/search/?q=beer';
 
-            assert.equal(extendQuery(oldUrl, newUrl), 'https://www.search.ru/?q=beer');
+            assert.equal(extendQuery(newUrl, oldUrl), 'https://www.search.ru/?q=beer');
         });
 
         it('обязательный для семны параметр стирается', function() {
             var newUrl = 'https://www.search.ru/';
             var oldUrl = 'https://www.search.ru/?q=beer';
 
-            assert.equal(extendQuery(oldUrl, newUrl, 'q'), 'https://www.search.ru/');
+            assert.equal(extendQuery(newUrl, oldUrl, 'q'), 'https://www.search.ru/');
         });
 
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slot",
-  "version": "0.13.15",
+  "version": "0.14.0",
   "homepage": "https://github.com/2gis/slot",
   "repository": "git@github.com:2gis/slot.git",
   "bugs": "https://github.com/2gis/slot/issues",
@@ -78,7 +78,6 @@
     "reqwest": "git://github.com/2gis/reqwest",
     "setimmediate": "^1.0.2",
     "ua-parser-js": "~0.7.9",
-    "url-parse": "~1.0.5",
     "wrench": "~1.5.8",
     "yargs": "^3.6.0"
   },


### PR DESCRIPTION
Transform добавлял парсинг, а потом снова ресолвинг урла для каждой ссылки.
В основном, вся оптимизация кроется в вырезании transform'а из permalink'а.
Чтобы его убрать и отказаться от репарсинга, пришлось урлы задавать в конфиге сразу в нужном виде (с ?queryState). В связи с этим пришлось также поправить expandString и pattern.compile.
+Изменился extendQuery, чтобы ему можно было передавать объект для расширения query-параметров - так удобнее и это оптимизирует онлайн.