### PR TITLE
improve-app.cookie-method-to-support-calling-without-any-args-on-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slot",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "homepage": "https://github.com/2gis/slot",
   "repository": "git@github.com:2gis/slot.git",
   "bugs": "https://github.com/2gis/slot/issues",


### PR DESCRIPTION
Согласно описанию метода app.cookie, он должен вести себя так же, как и jQuery. Однако при вызове метода с пустым набором аргументов на клиенте возвращаются все доступные куки, а на сервере не возвращается ничего. Исправил это несоответствие, заодно сделал метод чуть более читаемым (ИМХО).